### PR TITLE
chore: fix typo snowsql

### DIFF
--- a/snowflake/ml/utils/connection_params.py
+++ b/snowflake/ml/utils/connection_params.py
@@ -150,7 +150,7 @@ def SnowflakeLoginOptions(connection_name: str = "", login_file: Optional[str] =
     >> session = Session.builder.configs(SnowflakeLoginOptions()).create()
 
     Usage Note:
-      Ideally one should have a snoqsql config file. Read more here:
+      Ideally one should have a snowsql config file. Read more here:
       https://docs.snowflake.com/en/user-guide/snowsql-start.html#configuring-default-connection-settings
 
     Args:


### PR DESCRIPTION
There was a small typo in the docstring related to SnowflakeLoginOptions. 

I have corrected this now. 