### PR TITLE
feat(cortex): export complete ConversationMessage

### DIFF
--- a/snowflake/cortex/__init__.py
+++ b/snowflake/cortex/__init__.py
@@ -1,5 +1,5 @@
 from snowflake.cortex._classify_text import ClassifyText
-from snowflake.cortex._complete import Complete, CompleteOptions
+from snowflake.cortex._complete import Complete, CompleteOptions, ConversationMessage
 from snowflake.cortex._embed_text_768 import EmbedText768
 from snowflake.cortex._embed_text_1024 import EmbedText1024
 from snowflake.cortex._extract_answer import ExtractAnswer
@@ -11,6 +11,7 @@ __all__ = [
     "ClassifyText",
     "Complete",
     "CompleteOptions",
+    "ConversationMessage",
     "EmbedText768",
     "EmbedText1024",
     "ExtractAnswer",


### PR DESCRIPTION
Hello, I just noticed that `ConversationMessage` is not exported from `snowflake.cortex` so in our code we ended up importing `_complete` which doesnt seems ideal
```
from snowflake.cortex import Complete, CompleteOptions
from snowflake.cortex._complete import ConversationMessage
```
with this PR we could improve it to:
```
from snowflake.cortex import Complete, ConversationMessage, CompleteOptions
```

Thanks!