### PR TITLE
Add option for custom conda channel for checking packages exist

### DIFF
--- a/snowflake/ml/_internal/env_utils.py
+++ b/snowflake/ml/_internal/env_utils.py
@@ -1,5 +1,6 @@
 import collections
 import copy
+import os
 import pathlib
 import re
 import textwrap
@@ -35,7 +36,9 @@ _SUPPORTED_PACKAGE_SPEC_OPS = ["==", ">=", "<=", ">", "<"]
 DEFAULT_CHANNEL_NAME = ""
 SNOWML_SPROC_ENV = "IN_SNOWML_SPROC"
 SNOWPARK_ML_PKG_NAME = "snowflake-ml-python"
-SNOWFLAKE_CONDA_CHANNEL_URL = "https://repo.anaconda.com/pkgs/snowflake"
+SNOWFLAKE_CONDA_CHANNEL_URL = os.getenv(
+    "SNOWFLAKE_CONDA_CHANNEL_URL", "https://repo.anaconda.com/pkgs/snowflake"
+)
 
 
 def _validate_pip_requirement_string(req_str: str) -> requirements.Requirement:


### PR DESCRIPTION
Currently, the Snowflake Conda channel is hardcoded.  This is an issue in private/isolated environments that don't allow internet connectivity or when proxies such as JFrog are used. 
 
This PR allows for an environment variable `SNOWFLAKE_CONDA_CHANNEL_URL` to be set for an alternative Conda channel such as a JFrog proxy.

Default behavior is unchanged.