### PR TITLE
Add structured output support to `complete()` via `CompleteOptions`

### DIFF
--- a/snowflake/cortex/_complete.py
+++ b/snowflake/cortex/_complete.py
@@ -53,6 +53,9 @@ class CompleteOptions(TypedDict):
     """ A boolean value that controls whether Cortex Guard filters unsafe or harmful responses
     from the language model. """
 
+    response_format: NotRequired[dict[str, Any]]
+    """ A response format for structured output. """
+
 
 class ResponseParseException(Exception):
     """This exception is raised when the server response cannot be parsed."""
@@ -136,6 +139,8 @@ def _make_request_body(
                 "response_when_unsafe": "Response filtered by Cortex Guard",
             }
             data["guardrails"] = guardrails_options
+        if "response_format" in options:
+            data["response_format"] = options["response_format"]
     return data
 
 


### PR DESCRIPTION
This PR adds an optional `response_format` field to `CompleteOptions`, making it possible to do [structured output](https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-llm-rest-api#structured-output-example) via `complete()`,  like so:

```python
from snowflake.snowpark import Session
from snowflake.cortex import complete

session = Session.builder.configs(...).create()

complete(
  "mistral-large2",
  "Please prepare me a data set of 3 ppl and their age",
  session=session,
  options={
    "response_format": {
      "type": "json",
      "schema": {
          "type": "object",
          "properties": {
              "people": {
                  "type": "array",
                  "items": {
                      "type": "object",
                      "properties": {
                          "name": {
                              "type": "string"
                          },
                          "age": {
                              "type": "number"
                          }
                      },
                      "required": ["name", "age"]
                  }
              }
          },
          "required": ["people"]
      }
    }
  }
)
```