### PR TITLE
Fix ModelVersion.load in Container Runtime notebooks: download via session.file.get

### DIFF
--- a/snowflake/ml/model/_client/sql/model_version.py
+++ b/snowflake/ml/model/_client/sql/model_version.py
@@ -289,7 +289,6 @@ class ModelVersionSQLClient(_base._BaseSQLClient):
             scheme="snow", netloc="model", path=stage_location, params="", query="", fragment=""
         ).geturl()
         local_location = target_path.resolve().as_posix()
-        local_location_url = f"file://{local_location}"
 
         if snowpark_utils.is_in_stored_procedure():  # type: ignore[no-untyped-call]
             options = {"parallel": 10}
@@ -297,11 +296,14 @@ class ModelVersionSQLClient(_base._BaseSQLClient):
             cursor._download(stage_location_url, str(target_path), options)
             cursor.fetchall()
         else:
-            query_result_checker.SqlResultValidator(
-                self._session,
-                f"GET {_normalize_url_for_sql(stage_location_url)} {_normalize_url_for_sql(local_location_url)}",
-                statement_params=statement_params,
-            ).has_dimensions(expected_rows=1).validate()
+            get_results = self._session.file.get(
+                stage_location_url, local_location, statement_params=statement_params
+            )
+            if len(get_results) != 1:
+                raise ValueError(
+                    f"Expected to download exactly one file from {stage_location_url}, "
+                    f"but got {len(get_results)}."
+                )
         return target_path / file_path.name
 
     def show_functions(


### PR DESCRIPTION
## Problem

`ModelVersion.load()` fails inside a **Snowflake Container Runtime notebook** with:

```
ProgrammingError: 000710 (02000): Result for query <id> has expired
```

The notebook runtime monkeypatches `DataFrame.collect()` into a *cancellable async job* (`snowflake_notebook_utils.session_bootstrap`), which re-fetches results via `result_scan(<sfqid>)`. `ModelVersionSQLClient.get_file` downloads model files in its non-stored-procedure branch by running a raw `GET snow://model/... file://...` through `session.sql(...).collect()`. A `GET` produces no result set that `result_scan` can replay, so the async re-fetch returns "expired" and `load()` blows up.

Notably, **upload works** (`log_model`) because it uses `session.file.put` (`file_utils.upload_directory_to_stage`), which goes through the connector file-transfer path rather than `collect()`. The download path was asymmetric.

## Fix

Download via `session.file.get` — the `FileOperation` API symmetric to the `session.file.put` used when logging a model. It uses the connector file-transfer path and does not depend on `collect()`, so it is unaffected by the notebook's cancellable-collect patch. `snow://` is already an accepted GET prefix (`SNOWURL_PREFIX`), so the registry stage URL works unchanged.

The stored-procedure branch (which already uses the low-level `cursor._download`) is untouched. The previous `has_dimensions(expected_rows=1)` assertion is preserved as an explicit check that exactly one file was downloaded.

## Impact

- Fixes `ModelVersion.load()` / model download in Container Runtime notebooks.
- Makes model upload and download both go through the `FileOperation` API.
- No behavior change in stored procedures or warehouse contexts.